### PR TITLE
Limit the number of lines used for charset detection

### DIFF
--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -50,11 +50,14 @@ def detect_encoding(bytes):
     """Detect encoding of a byte stream.
     """
     detector = UniversalDetector()
-    for line in bytes.readlines():
+    num_lines = 1000
+    while num_lines > 0:
+        line = bytes.readline()
         detector.feed(line)
         if detector.done:
             # TODO: does it work?
             break
+        num_lines -= 1
     detector.close()
     bytes.seek(0)
     confidence = detector.result['confidence']


### PR DESCRIPTION
Right now it uses the entire file for detection, which just takes an awful lot of time.

