### PR TITLE
Fix support for UTF-8 files with BOM

### DIFF
--- a/data/special/bom.csv
+++ b/data/special/bom.csv
@@ -1,0 +1,3 @@
+﻿id,name
+1,english
+2,中国人

--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import codecs
 import os
 import re
 import six
@@ -60,9 +61,17 @@ def detect_format(source):
     return format
 
 
-def detect_encoding(bytes):
+def detect_encoding(bytes, encoding=None):
     """Detect encoding of a byte stream.
     """
+    if encoding is not None:
+        if encoding.lower() == 'utf-8':
+            prefix = bytes.read(len(codecs.BOM_UTF8))
+            if prefix == codecs.BOM_UTF8:
+                encoding = 'utf-8-sig'
+            bytes.seek(0)
+        return encoding
+
     CHARDET_DETECTION_MAX_LINES = 1000
     CHARDET_DETECTION_MIN_CONFIDENCE = 0.5
     detector = UniversalDetector()

--- a/tabulator/loaders/file.py
+++ b/tabulator/loaders/file.py
@@ -32,8 +32,7 @@ class FileLoader(api.Loader):
         bytes = io.open(source, 'rb')
 
         # Prepare encoding
-        if encoding is None:
-            encoding = helpers.detect_encoding(bytes)
+        encoding = helpers.detect_encoding(bytes, encoding)
 
         # Return or raise
         if mode == 'b':

--- a/tabulator/loaders/stream.py
+++ b/tabulator/loaders/stream.py
@@ -32,8 +32,7 @@ class StreamLoader(api.Loader):
         bytes = source
 
         # Prepare encoding
-        if encoding is None:
-            encoding = helpers.detect_encoding(bytes)
+        encoding = helpers.detect_encoding(bytes, encoding)
 
         # Return or raise
         if mode == 'b':

--- a/tabulator/loaders/web.py
+++ b/tabulator/loaders/web.py
@@ -44,8 +44,8 @@ class WebLoader(api.Loader):
                 encoding = response.headers.getparam('charset')
             else:
                 encoding = response.headers.get_content_charset()
-        if encoding is None:
-            encoding = helpers.detect_encoding(bytes)
+
+        encoding = helpers.detect_encoding(bytes, encoding)
 
         # Return or raise
         if mode == 'b':

--- a/tests/test_topen.py
+++ b/tests/test_topen.py
@@ -39,6 +39,23 @@ def test_file_csv_parser_options():
     assert table.headers is None
     assert table.read() == [['id', 'name'], ['1', 'english'], ['2', '中国人']]
 
+def test_file_csv_with_bom():
+
+    # Get table
+    table = topen('data/special/bom.csv', encoding='utf-8')
+
+    # Make assertions
+    assert table.headers is None
+    assert table.read() == [['id', 'name'], ['1', 'english'], ['2', '中国人']]
+
+    # Get table
+    table = topen('data/special/bom.csv')
+
+    # Make assertions
+    assert table.headers is None
+    assert table.read() == [['id', 'name'], ['1', 'english'], ['2', '中国人']]
+
+
 
 # DEPRECATED [v0.5-v1)
 def test_file_csv_parser_class():


### PR DESCRIPTION
Coercre provided 'utf-8' to Python's 'utf-8-sig' for proper decoding