### PR TITLE
Updated readme, makefile, dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install list release test version
+.PHONY: all install list test version
 
 
 PACKAGE := $(shell grep '^PACKAGE =' setup.py | cut -d "'" -f2)
@@ -12,11 +12,6 @@ install:
 
 list:
 	@grep '^\.PHONY' Makefile | cut -d' ' -f2- | tr ' ' '\n'
-
-release:
-	bash -c '[[ -z `git status -s` ]]'
-	git tag -a -m release $(VERSION)
-	git push --tags
 
 test:
 	pylama $(PACKAGE)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ with Stream('path.csv', headers=1) as stream:
         print(row)  # will print row values list
 ```
 
-## Documentation
-
 ### Stream
 
 `Stream` takes the `source` argument:
@@ -86,14 +84,39 @@ stream.save('target.csv')
 stream.close()
 ```
 
-### exceptions
+## API Reference
 
-The library provides various of exceptions. Please consult with docstrings.
+### Snapshot
 
-## Read more
+```
+Stream(source,
+       headers=None,
+       scheme=None,
+       format=None,
+       encoding=None,
+       post_parse=None,
+       sample_size=None,
+       loader_options=None,
+       parser_options=None)
+    closed/open/close/reset
+    headers -> list
+    sample -> rows
+    iter(keyed/extended=False) -> (generator) (keyed/extended)row[]
+    read(keyed/extended=False, limit=None) -> (keyed/extended)row[]
+    save(target, format=None, encoding=None, **writer_options)
+exceptions
+~cli
+```
+
+### Detailed
 
 - [Docstrings](https://github.com/frictionlessdata/tabulator-py/tree/master/tabulator)
 - [Changelog](https://github.com/frictionlessdata/tabulator-py/commits/master)
-- [Contribute](CONTRIBUTING.md)
+
+## Contributing
+
+Please read the contribution guideline:
+
+[How to Contribute](CONTRIBUTING.md)
 
 Thanks!

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ INSTALL_REQUIRES = [
     'openpyxl>=2.4,<3.0a',
     'requests>=2.8,<3.0a',
     'beautifulsoup4>=4.4,<5.0a',
-    'linear-tsv>=0.99,<0.100a',
+    'linear-tsv>=1.0,<2.0a',
     'unicodecsv>=0.14,<0.15a',
 ]
 TESTS_REQUIRE = [


### PR DESCRIPTION
# Overview

This improving readme structure and removing `make release` (use github releases instead). Also rebase on tsv parser v1.

# Issues

- fixes #96