### PR TITLE
Add `lineterminator` to the csv parsing options

### DIFF
--- a/tabulator/parsers/csv.py
+++ b/tabulator/parsers/csv.py
@@ -28,6 +28,7 @@ class CSVParser(api.Parser):
         'quotechar',
         'quoting',
         'skipinitialspace',
+        'lineterminator'
     ]
 
     def __init__(self, **options):


### PR DESCRIPTION
This is required for consistency reasons, as both the python csv parser and the CSV dialect spec support it