### PR TITLE
[Review] added a (failing) test-case for parsing html content as txt format

### DIFF
--- a/data/table.html
+++ b/data/table.html
@@ -1,0 +1,4 @@
+<html><table>
+<tr><td>english</td></tr>
+<tr><td>中国人</td></tr>
+</table></html>

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -93,6 +93,11 @@ def test_stream_txt():
     with Stream(source) as stream:
         assert stream.read() == [['english'], ['中国人']]
 
+def test_stream_txt_html():
+    source = 'data/table.html'
+    with Stream(source, format="txt") as stream:
+        assert stream.read() == [['<html><table>'], ['<tr><td>english</td></tr>'], ['<tr><td>中国人</td></tr>'], ['</table></html>']]
+
 
 # Tests [options]
 


### PR DESCRIPTION
This PR adds an additional (failing) test-case for PR #154 - add support for txt format

This is the main use-case for us - loading html content as plain text and parsing it using datapackage pipeline processors and workflows.

It fails due to the following line in tabulator.stream.Stream.open function:
```
self.__detect_html()
```

This function raises a FormatError in case it detects html content in the sample rows

### possible solutions
* Don't run this function when format is "txt"
* Raise a differect exception (e.g. HtmlFormatError) - allowing to catch and ignore this error (this will work assuming the __detect_html function is called last and all further processing is only related to non-html content)
* Add a parameter to Stream that will cause it not to check for html content
