### PR TITLE
Allow to use data packages as a tabular source

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,21 @@ Operations:
 Options:
 - sheet - sheet number starting from 1
 
+#### datapackage
+> This format is not included to package by default. To use it please install `tabulator` with an `datapackage` extras: `$ pip install tabulator[datapackage]`
+
+Source should be a valid Tabular Data Package see (https://frictionlessdata.io).
+
+```python
+stream = Stream('datapackage.json', resource=1)
+```
+
+Operations:
+- read
+
+Options:
+- resource - resource index (starting from 0) or resource name
+
 ### Encoding
 
 `Stream` constructor accepts `encoding` argument to ensure needed encoding will be used. As a value argument supported by python encoding name could be used:

--- a/data/datapackage.json
+++ b/data/datapackage.json
@@ -1,0 +1,33 @@
+{
+  "name": "test-tabulator",
+  "resources": [
+    { "name": "first-resource",
+      "path": "table.xls",
+      "schema": {
+        "fields": [
+          {
+            "name": "id",
+            "type": "integer"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {"name": "number-two", "path": "table-reverse.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "id",
+            "type": "integer"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }}
+  ]
+}

--- a/data/table-reverse.csv
+++ b/data/table-reverse.csv
@@ -1,0 +1,3 @@
+id,name
+1,中国人
+2,english

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ INSTALL_FORMAT_ODS_REQUIRES = [
     'ezodf>=0.3,<1.0',
     'lxml>=3.0,<4.0',
 ]
+INSTALL_FORMAT_DATAPACKAGE_REQUIRES = [
+    'datapackage<1.0',
+]
 TESTS_REQUIRE = [
     'pylama',
     'tox',
@@ -55,6 +58,7 @@ setup(
     tests_require=TESTS_REQUIRE,
     extras_require={
         'ods': INSTALL_FORMAT_ODS_REQUIRES,
+        'datapackage': INSTALL_FORMAT_DATAPACKAGE_REQUIRES,
         'develop': TESTS_REQUIRE,
     },
     entry_points={

--- a/tabulator/config.py
+++ b/tabulator/config.py
@@ -31,6 +31,7 @@ LOADERS = {
 
 PARSERS = {
     'csv': 'tabulator.parsers.csv.CSVParser',
+    'datapackage': 'tabulator.parsers.datapackage.DataPackageParser',
     'gsheet': 'tabulator.parsers.gsheet.GsheetParser',
     'inline': 'tabulator.parsers.inline.InlineParser',
     'json': 'tabulator.parsers.json.JSONParser',

--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -43,16 +43,17 @@ def detect_scheme_and_format(source):
         if source.startswith('%s://' % sql_scheme):
             return (None, 'sql')
 
-    # Format: datapackage
-    if source.endswith('/datapackage.json'):
-        return (None, 'datapackage')
-
     # General
     parsed = urlparse(source)
     scheme = parsed.scheme.lower()
     if len(scheme) < 2:
         scheme = config.DEFAULT_SCHEME
     format = os.path.splitext(parsed.path or parsed.netloc)[1][1:].lower() or None
+
+    # Format: datapackage
+    if parsed.path.endswith('datapackage.json'):
+        return (None, 'datapackage')
+
     return (scheme, format)
 
 

--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -43,6 +43,10 @@ def detect_scheme_and_format(source):
         if source.startswith('%s://' % sql_scheme):
             return (None, 'sql')
 
+    # Format: datapackage
+    if source.endswith('/datapackage.json'):
+        return (None, 'datapackage')
+
     # General
     parsed = urlparse(source)
     scheme = parsed.scheme.lower()

--- a/tabulator/parsers/datapackage.py
+++ b/tabulator/parsers/datapackage.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import datapackage
+import six
+
+from ..parser import Parser
+
+
+# Module API
+
+class DataPackageParser(Parser):
+    """Parser to extract data from Tabular Data Packages.
+
+    See: http://specs.frictionlessdata.io/
+    """
+
+    # Public
+
+    options = [
+        'resource',
+    ]
+
+    def __init__(self, loader, resource=0):
+        self.__resource = resource
+        self.__extended_rows = None
+        self.__force_parse = None
+        self.__datapackage = None
+        self.__resource_iter = None
+
+    @property
+    def closed(self):
+        return self.__resource_iter is None
+
+    def open(self, source, encoding=None, force_parse=False):
+        self.close()
+        self.__force_parse = force_parse
+        self.__datapackage = datapackage.DataPackage(source)
+        self.reset()
+
+    def close(self):
+        if not self.closed:
+            self.__datapackage = None
+            self.__resource_iter = None
+            self.__extended_rows = None
+
+    def reset(self):
+        if isinstance(self.__resource, six.string_types):
+            print(self.__datapackage.resources)
+            named_resource = next(iter(filter(
+                lambda res: res.descriptor['name'] == self.__resource,
+                self.__datapackage.resources
+            )))
+            self.__resource_iter = named_resource.iter()
+        else:
+            self.__resource_iter = \
+                self.__datapackage.resources[self.__resource].iter()
+        self.__extended_rows = self.__iter_extended_rows()
+
+    @property
+    def extended_rows(self):
+        return self.__extended_rows
+
+    # Private
+
+    def __iter_extended_rows(self):
+        for number, row in enumerate(self.__resource_iter, start=1):
+            keys, values = zip(*sorted(row.items()))
+            yield number, list(keys), list(values)

--- a/tabulator/parsers/datapackage.py
+++ b/tabulator/parsers/datapackage.py
@@ -49,11 +49,10 @@ class DataPackageParser(Parser):
 
     def reset(self):
         if isinstance(self.__resource, six.string_types):
-            print(self.__datapackage.resources)
             named_resource = next(iter(filter(
                 lambda res: res.descriptor['name'] == self.__resource,
                 self.__datapackage.resources
-            )))
+            )))  # TODO: use data_package.getResource(name) when v1 is released
             self.__resource_iter = named_resource.iter()
         else:
             self.__resource_iter = \

--- a/tests/formats/test_datapackage.py
+++ b/tests/formats/test_datapackage.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import json
+from mock import Mock
+import pytest
+
+from tabulator import Stream
+from tabulator.parsers.datapackage import DataPackageParser
+
+
+# Tests
+
+def test_datapackage_parser():
+
+    source = 'data/datapackage.json'
+    parser = DataPackageParser(None)
+
+    assert parser.closed is True
+    parser.open(source, None, None)
+    assert parser.closed is False
+
+    assert list(parser.extended_rows) == [
+        (1, ['id', 'name'], [1, 'english']),
+        (2, ['id', 'name'], [2, '中国人']),
+    ]
+
+    assert len(list(parser.extended_rows)) == 0
+    parser.reset()
+    assert len(list(parser.extended_rows)) == 2
+
+    parser.close()
+    assert parser.closed
+
+
+def test_stream_datapackage():
+    with Stream('data/datapackage.json', resource=0, headers=1) as stream:
+        assert stream.headers == ['id', 'name']
+        assert stream.read(keyed=True) == [
+            {'id': 1, 'name': 'english'},
+            {'id': 2, 'name': '中国人'}]
+
+
+def test_second_resource():
+    with Stream('data/datapackage.json', resource=1, headers=1) as stream:
+        assert stream.headers == ['id', 'name']
+        assert stream.read(keyed=True) == [
+            {'id': 1, 'name': '中国人'},
+            {'id': 2, 'name': 'english'}
+        ]
+
+
+def test_named_resource():
+    with Stream('data/datapackage.json', resource='number-two', headers=1) as stream:
+        assert stream.headers == ['id', 'name']
+        assert stream.read(keyed=True) == [
+            {'id': 1, 'name': '中国人'},
+            {'id': 2, 'name': 'english'},
+        ]
+
+
+def test_datapackage_list():
+    curdir= os.getcwd()
+    try:
+        os.chdir('data/')
+        stream = json.load(open('datapackage.json'))
+
+        parser = DataPackageParser(None)
+        parser.open(stream, None, None)
+
+        assert list(parser.extended_rows) == [
+            (1, ['id', 'name'], [1, 'english']),
+            (2, ['id', 'name'], [2, '中国人'])
+        ]
+    finally:
+        os.chdir(curdir)

--- a/tests/formats/test_datapackage.py
+++ b/tests/formats/test_datapackage.py
@@ -55,12 +55,17 @@ def test_second_resource():
 
 
 def test_named_resource():
-    with Stream('data/datapackage.json', resource='number-two', headers=1) as stream:
-        assert stream.headers == ['id', 'name']
-        assert stream.read(keyed=True) == [
-            {'id': 1, 'name': '中国人'},
-            {'id': 2, 'name': 'english'},
-        ]
+    curdir = os.getcwd()
+    try:
+        os.chdir('data/')
+        with Stream('datapackage.json', resource='number-two', headers=1) as stream:
+            assert stream.headers == ['id', 'name']
+            assert stream.read(keyed=True) == [
+                {'id': 1, 'name': '中国人'},
+                {'id': 2, 'name': 'english'},
+            ]
+    finally:
+        os.chdir(curdir)
 
 
 def test_datapackage_list():

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist=
 [testenv]
 extras=
   ods
+  datapackage
 deps=
   mock
   pytest


### PR DESCRIPTION
fixes #161 

---

I added the possibility to use data packages as resources in tabulator.

I know that `datapackage` uses `tabulator` internally, but from tabulator's point of view it's just another data container (same as xls, ods or csv).