### PR TITLE
Reset row pointer on stream.close

### DIFF
--- a/tabulator/stream.py
+++ b/tabulator/stream.py
@@ -162,6 +162,7 @@ class Stream(object):
         """https://github.com/frictionlessdata/tabulator-py#stream
         """
         self.__parser.close()
+        self.__row_number = 0
 
     def reset(self):
         """https://github.com/frictionlessdata/tabulator-py#stream

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -486,7 +486,7 @@ def test_stream_save_xls(tmpdir):
 
 # Issues
 
-def test_stream_reset_on_close():
+def test_stream_reset_on_close_issue_190():
     source = [['1', 'english'], ['2', '中国人']]
     stream = Stream(source)
     stream.open()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -482,3 +482,15 @@ def test_stream_save_xls(tmpdir):
         with pytest.raises(exceptions.FormatError) as excinfo:
             stream.save(target)
         assert 'xls' in str(excinfo.value)
+
+
+# Issues
+
+def test_stream_reset_on_close():
+    source = [['1', 'english'], ['2', '中国人']]
+    stream = Stream(source)
+    stream.open()
+    stream.read(limit=1) == [['1', 'english']]
+    stream.open()
+    stream.read(limit=1) == [['1', 'english']]
+    stream.close()


### PR DESCRIPTION
- fixes #190 

---

It wasn't a bug as test has shown but still better to reset a pointer on `stream.close`.