### PR TITLE
Strip BOM from text detected as UTF-16

### DIFF
--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -63,7 +63,7 @@ def _canonical_encoding(sample, encoding):
     """Give encoding name in canonical form and correct 'utf-8-sig'."""
     encoding = codecs.lookup(encoding).name
     # Work around 'Incorrect detection of utf-8-sig encoding'
-    # <https://github.com/PyYoshi/cChardet/issues/28>    
+    # <https://github.com/PyYoshi/cChardet/issues/28>
     if encoding == 'utf-8':
         if sample.startswith(codecs.BOM_UTF8):
             encoding = 'utf-8-sig'

--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -67,6 +67,13 @@ def _canonical_encoding(sample, encoding):
         # <https://github.com/PyYoshi/cChardet/issues/28>
         if sample.startswith(codecs.BOM_UTF8):
             encoding = 'utf-8-sig'
+    # Use the BOM stripping name (without byte-order) for UTF-16 encodings
+    elif encoding == 'utf-16-be':
+        if sample.startswith(codecs.BOM_UTF16_BE):
+            encoding = 'utf-16'
+    elif encoding == 'utf-16-le':
+        if sample.startswith(codecs.BOM_UTF16_LE):
+            encoding = 'utf-16'
     return encoding
 
 

--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -59,23 +59,28 @@ def detect_scheme_and_format(source):
     return (scheme, format)
 
 
+def _canonical_encoding(sample, encoding):
+    """Give encoding name in canonical form and correct 'utf-8-sig'."""
+    encoding = codecs.lookup(encoding).name
+    if encoding == 'utf-8':
+        # Work around 'Incorrect detection of utf-8-sig encoding'
+        # <https://github.com/PyYoshi/cChardet/issues/28>
+        if sample.startswith(codecs.BOM_UTF8):
+            encoding = 'utf-8-sig'
+    return encoding
+
+
 def detect_encoding(sample, encoding=None):
     """Detect encoding of a byte string sample.
     """
     # To reduce tabulator import time
     from cchardet import detect
-    def detect_utf8_sig(sample, encoding):
-        if encoding == 'utf-8':
-            if sample.startswith(codecs.BOM_UTF8):
-                encoding = 'utf-8-sig'
-        return encoding
     if encoding is not None:
-        encoding = encoding.lower()
-        return detect_utf8_sig(sample, encoding)
+        return _canonical_encoding(sample, encoding)
     result = detect(sample)
     confidence = result['confidence'] or 0
-    encoding = (result['encoding'] or '').lower()
-    encoding = detect_utf8_sig(sample, encoding)
+    encoding = result['encoding'] or 'ascii'
+    encoding = _canonical_encoding(sample, encoding)
     if confidence < config.ENCODING_CONFIDENCE:
         encoding = config.DEFAULT_ENCODING
     if encoding == 'ascii':

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -48,6 +48,16 @@ def test_detect_encoding_windows_1252():
     assert helpers.detect_encoding(sample) == 'cp1252'
 
 
+def test_detect_encoding_utf_16_be():
+    sample = u'\uFEFFthen some text'.encode('utf-16-be')
+    assert helpers.detect_encoding(sample) == 'utf-16'
+
+
+def test_detect_encoding_utf_16_le():
+    sample = u'\uFEFFthen some text'.encode('utf-16-le')
+    assert helpers.detect_encoding(sample) == 'utf-16'
+
+
 def test_detect_encoding_unknown():
     sample = b'\xff\x81'
     assert helpers.detect_encoding(sample) == 'utf-8'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -45,7 +45,7 @@ def test_detect_encoding():
 
 def test_detect_encoding_windows_1252():
     sample = b'A\n' * 300 + b'\xff\xff'
-    assert helpers.detect_encoding(sample) == 'windows-1252'
+    assert helpers.detect_encoding(sample) == 'cp1252'
 
 
 def test_detect_encoding_unknown():

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -154,7 +154,7 @@ def test_stream_encoding_explicit_utf8():
 
 def test_stream_encoding_explicit_latin1():
     with Stream('data/special/latin1.csv', encoding='latin1') as stream:
-        assert stream.encoding == 'latin1'
+        assert stream.encoding == 'iso8859-1'
         assert stream.read() == [['id', 'name'], ['1', 'english'], ['2', '©']]
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -158,6 +158,14 @@ def test_stream_encoding_explicit_latin1():
         assert stream.read() == [['id', 'name'], ['1', 'english'], ['2', '©']]
 
 
+def test_stream_encoding_utf_16():
+    # Bytes encoded as UTF-16 with BOM in platform order is detected
+    bio = io.BytesIO(u'en,English\nja,日本語'.encode('utf-16'))
+    with Stream(bio, format='csv') as stream:
+        assert stream.encoding == 'utf-16'
+        assert stream.read() == [[u'en', u'English'], [u'ja', u'日本語']]
+
+
 # Sample size
 
 def test_stream_sample():


### PR DESCRIPTION
Depends on #193.

The name returned from cchardet includes the byte-order suffix, but
for Python codecs that means do not handle the BOM. Switching to
plain 'UTF-16' ensures the BOM is stripped.

Note that cchardet does not detect an encoding for UTF-16 files
without a BOM, but the code ensures the mapping only happens when
the expected BOM is actually present.