### PR TITLE
fix: resource_iter as a list of dictionaries

### DIFF
--- a/tabulator/parsers/datapackage.py
+++ b/tabulator/parsers/datapackage.py
@@ -53,11 +53,11 @@ class DataPackageParser(Parser):
                 lambda res: res.descriptor['name'] == self.__resource,
                 self.__datapackage.resources
             )))  # TODO: use data_package.getResource(name) when v1 is released
-            self.__resource_iter = named_resource.iter()
+            self.__resource_iter = named_resource.iter(keyed=True)
             self.__encoding = named_resource.descriptor.get('encoding')
         else:
             indexed_resource = self.__datapackage.resources[self.__resource]
-            self.__resource_iter = indexed_resource.iter()
+            self.__resource_iter = indexed_resource.iter(keyed=True)
             self.__encoding = indexed_resource.descriptor.get('encoding')
         self.__extended_rows = self.__iter_extended_rows()
 


### PR DESCRIPTION
Fixes
```
  File ".../python3.6/site-packages/tabulator/parsers/datapackage.py", line 76, in __iter_extended_rows
    keys, values = zip(*sorted(row.items()))
AttributeError: 'list' object has no attribute 'items'
```


[`resource.iter()`](https://github.com/frictionlessdata/datapackage-py#resourceiterkeyedfase-extendedfalse-casttrue-relationsfalse) emits lists by default, and dictionaries if  `keyed=True` is specified. 

`__iter_extended_rows` expects the rows to be dictionaries