### PR TITLE
Lower the SQLAlchemy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIRES = [
     # Format: ndjson
     'jsonlines>=1.1,<2.0',
     # Format: sql
-    'sqlalchemy>=1.1,<2.0',
+    'sqlalchemy>=0.9.6,<2.0',
     # Format: tsv
     'linear-tsv>=1.0,<2.0',
     # Format: xls


### PR DESCRIPTION
This version will ensure compatibility with more CKAN versions, as older versions than the current one are stuck with SA 0.9.6.

All tests pass when using 0.9.6 and I have reviewed the code looking for potential backward incompatible things, without finding anything.