### PR TITLE
Add fail_unused_options option with default False

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Create stream class instance.
 - `custom_parsers (dict)` - custom parsers keyed by format. See a section below. See [custom parsers](https://github.com/frictionlessdata/tabulator-py#custom-parsers) section.
 - `custom_writers (dict)` - custom writers keyed by format. See a section below. See [custom writers](https://github.com/frictionlessdata/tabulator-py#custom-writers) section.
 - `<name> (<type>)` - loader/parser options. See in the scheme/format section
+- `fail_unused_options (bool)` - if `True` throw exception if any options are not used with `False` as default.
 - `(Stream)` - returns Stream class instance
 
 #### `stream.closed`

--- a/tabulator/stream.py
+++ b/tabulator/stream.py
@@ -40,6 +40,7 @@ class Stream(object):
                  custom_loaders={},
                  custom_parsers={},
                  custom_writers={},
+                 fail_unused_options=False,
                  **options):
         """https://github.com/frictionlessdata/tabulator-py#stream
         """
@@ -93,6 +94,7 @@ class Stream(object):
         self.__actual_scheme = scheme
         self.__actual_format = format
         self.__actual_encoding = encoding
+        self.__fail_unused_options = fail_unused_options
         self.__options = options
         self.__sample_extended_rows = []
         self.__loader = None
@@ -202,7 +204,9 @@ class Stream(object):
         if options:
             message = 'Not supported options "%s" for scheme "%s" and format "%s"'
             message = message % (', '.join(options), scheme, format)
-            raise exceptions.TabulatorException(message)
+            if self.__fail_unused_options:
+                raise exceptions.TabulatorException(message)
+            print(message)
 
         # Open and setup
         self.__parser.open(self.__source, encoding=self.__encoding)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -442,8 +442,9 @@ def test_stream_format_error():
 
 
 def test_stream_options_error():
+    Stream('', scheme='text', format='csv', bad_option=True).open()
     with pytest.raises(exceptions.TabulatorException) as excinfo:
-        Stream('', scheme='text', format='csv', bad_option=True).open()
+        Stream('', scheme='text', format='csv', fail_unused_options=True, bad_option=True).open()
     assert 'bad_option' in str(excinfo.value)
 
 


### PR DESCRIPTION
Only print message for extra options by default. 
(NB: there is no logging set up in Tabulator so I just used print rather than add a logger like colorlog).