### PR TITLE
Adds unicode support to the stringify function

### DIFF
--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -173,4 +173,4 @@ def stringify_value(value):
     isoformat = getattr(value, 'isoformat', None)
     if isoformat is not None:
         value = isoformat()
-    return str(value)
+    return type(u'')(value)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -110,3 +110,9 @@ def test_extract_options():
 def test_detect_html(sample):
     text, is_html = sample
     assert helpers.detect_html(text) is is_html
+
+
+def test_stringify_value():
+    sample = '\u4e9c'.encode('utf-8-sig').decode("utf-8")
+    assert helpers.stringify_value(sample) == sample
+


### PR DESCRIPTION
Up to now the stringify function raised encoding errors for unicode on python 2.
builtins.str is not available in the tox python version.
Therefore generate the appropriate unicode string class to cast the string independent of python version.