### PR TITLE
Bump click requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ PACKAGE = 'tabulator'
 INSTALL_REQUIRES = [
     # General
     'six>=1.9,<2.0',
-    'click>=6.0,<7.0',
+    'click>=7.0,<8.0',
     'requests>=2.8,<3.0',
     'cchardet>=1.0,<2.0',
     # Format: csv

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ PACKAGE = 'tabulator'
 INSTALL_REQUIRES = [
     # General
     'six>=1.9,<2.0',
-    'click>=7.0,<8.0',
+    'click>=6.0,<8.0',
     'requests>=2.8,<3.0',
     'cchardet>=1.0,<2.0',
     # Format: csv


### PR DESCRIPTION
The limited click versions creates dependency conflicts with other libs using the latest click version.