### PR TITLE
Stringify None values as empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ with Stream(source, format='csv', headers=1, ignore_blank_headers=True) as strea
 ##### Force strings
 
 When `True`, all rows' values will be converted to strings (defaults to
-`False`).
+`False`). `None` values will be converted to empty strings.
 
 ```python
 # Default behaviour

--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -176,6 +176,8 @@ def extract_options(options, names):
 def stringify_value(value):
     """Convert any value to string.
     """
+    if value is None:
+        return u''
     isoformat = getattr(value, 'isoformat', None)
     if isoformat is not None:
         value = isoformat()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -118,3 +118,7 @@ def test_stringify_value():
     sample = '\u4e9c'.encode('utf-8-sig').decode("utf-8")
     assert helpers.stringify_value(sample) == sample
 
+
+def test_stringify_value_none():
+    assert helpers.stringify_value(None) == ''
+


### PR DESCRIPTION
When using the 'force_strings' parameter on Excel files, you might get 'None' as a value for some cells.
This is obviously a bad outcome as it exposes some internal implementation and requires special handling for this special case.
An empty string is more apt in these cases.