### PR TITLE
Stream: Don't try to detect scheme and format if already given

### DIFF
--- a/tabulator/stream.py
+++ b/tabulator/stream.py
@@ -178,16 +178,19 @@ class Stream(object):
         '''Opens the stream for reading.'''
         options = copy(self.__options)
 
-        # Get scheme and format
-        detected_scheme, detected_format = helpers.detect_scheme_and_format(self.__source)
-        scheme = self.__scheme or detected_scheme
-        format = self.__format or detected_format
-
-        # Get compression
+        # Get scheme and format if not already given
         compression = None
-        for type in config.SUPPORTED_COMPRESSION:
-            if self.__compression == type or detected_format == type:
-                compression = type
+        if self.__scheme is None or self.__format is None:
+            detected_scheme, detected_format = helpers.detect_scheme_and_format(self.__source)
+            scheme = self.__scheme or detected_scheme
+            format = self.__format or detected_format
+            # Get compression
+            for type in config.SUPPORTED_COMPRESSION:
+                if self.__compression == type or detected_format == type:
+                    compression = type
+        else:
+            scheme = self.__scheme
+            format = self.__format
 
         # Initiate loader
         self.__loader = None

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -114,6 +114,19 @@ def test_stream_headers_strip_and_non_strings():
         assert stream.read() == [['value1', 'value2', 'value3', 'value4']]
 
 
+# Compression errors
+
+def test_stream_compression_error_gz():
+    source = 'id,filename\n\1,dump.tar.gz'
+    stream = Stream(source, scheme='text', format='csv')
+    stream.open()
+
+def test_stream_compression_error_zip():
+    source = 'id,filename\n1,archive.zip'
+    stream = Stream(source, scheme='text', format='csv')
+    stream.open()
+
+
 # Scheme
 
 def test_stream_scheme_file():


### PR DESCRIPTION
```python
stream = Stream(
	'size,filename\n3M,archive.zip',
	scheme='text',
	format='csv'
)
stream.open()
```
raises an exception:
```bash
Traceback (most recent call last):
  File "test_zip.py", line 9, in <module>
    stream.open()
  File "/home/pdi/.local/lib/python2.7/site-packages/tabulator/stream.py", line 237, in open
    raise exceptions.TabulatorException(message % compression)
tabulator.exceptions.TabulatorException: Compression "zip" is not supported for your Python version
```

This code
```python
stream = Stream(
	'size,filename\n3M,foobar.gz',
	scheme='text',
	format='csv'
)
stream.open()
```
also:
```bash
Traceback (most recent call last):
  File "test_gz.py", line 9, in <module>
    stream.open()
  File "/home/pdi/.local/lib/python2.7/site-packages/tabulator/stream.py", line 237, in open
    raise exceptions.TabulatorException(message % compression)
tabulator.exceptions.TabulatorException: Compression "gz" is not supported for your Python version
```

This is due to Stream open() function that try to re-detect scheme and format from csv content and handle csv content as a filename with extension ".gz" or ".zip"