### PR TITLE
Generate API Reference from docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ readme:
 	pip install md-toc
 	pip install referencer
 	referencer $(PACKAGE) README.md --in-place
-	md_toc -p README.md github --header-levels 3
+	md_toc -p README.md github --header-levels 4
 	sed -i '/(#$(PACKAGE)-py)/,+2d' README.md
 
 release:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ list:
 
 readme:
 	pip install md-toc
-	md_toc -p README.md github --header-levels 5
+	pip install referencer
+	referencer $(PACKAGE) README.md --in-place
+	md_toc -p README.md github --header-levels 3
 	sed -i '/(#$(PACKAGE)-py)/,+2d' README.md
 
 release:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ readme:
 	pip install md-toc
 	pip install referencer
 	referencer $(PACKAGE) README.md --in-place
-	md_toc -p README.md github --header-levels 4
+	md_toc -p README.md github --header-levels 3
 	sed -i '/(#$(PACKAGE)-py)/,+2d' README.md
 
 release:

--- a/README.md
+++ b/README.md
@@ -802,10 +802,6 @@ looking into the [tabulator.exceptions][tabulator.exceptions] module.
 
 ## API Reference
 
-The API reference is written as docstrings in the tabulator classes. A good
-place to start is the [Stream](tabulator/stream.py) class, which manages all
-loading and parsing of data files.
-
 ## Contributing
 
 This project follows the [Open Knowledge International coding standards](https://github.com/okfn/coding-standards).

--- a/README.md
+++ b/README.md
@@ -791,9 +791,9 @@ to stream its parsed contents.
 __Arguments__
 
 - __source (str)__:
-- __Path to file as ``<scheme>__://path/to/file.<format>``. If
-        not explicitly set, the scheme (file, http, ...) and format (csv, xls,
-        ...) are inferred from the source string.
+        Path to file as ``<scheme>://path/to/file.<format>``.
+        If not explicitly set, the scheme (file, http, ...) and
+        format (csv, xls, ...) are inferred from the source string.
 - __headers (Union[int, List[int], List[str]], optional)__:
         Either a row
         number or list of row numbers (in case of multi-line headers) to be

--- a/README.md
+++ b/README.md
@@ -27,73 +27,16 @@ A library for reading and writing tabular data (csv/xls/json/etc).
     - [Running on CLI](#running-on-cli)
     - [Running on Python](#running-on-python)
   - [Documentation](#documentation)
-    - [Stream](#stream)
-      - [Headers](#headers)
-      - [Encoding](#encoding)
-      - [Compression (Python3-only)](#compression-python3-only)
-      - [Allow html](#allow-html)
-      - [Sample size](#sample-size)
-      - [Bytes sample size](#bytes-sample-size)
-      - [Ignore blank headers](#ignore-blank-headers)
-      - [Force strings](#force-strings)
-      - [Force parse](#force-parse)
-      - [Skip rows](#skip-rows)
-      - [Post parse](#post-parse)
-      - [Keyed and extended rows](#keyed-and-extended-rows)
+    - [Working with Stream](#working-with-stream)
     - [Supported schemes](#supported-schemes)
-      - [s3](#s3)
-      - [file](#file)
-      - [http/https/ftp/ftps](#httphttpsftpftps)
-      - [stream](#stream-1)
-      - [text](#text)
     - [Supported file formats](#supported-file-formats)
-      - [csv (read & write)](#csv-read--write)
-      - [xls/xlsx (read & write)](#xlsxlsx-read--write)
-      - [ods (read only)](#ods-read-only)
-      - [gsheet (read only)](#gsheet-read-only)
-      - [sql (read & write)](#sql-read--write)
-      - [Data Package (read only)](#data-package-read-only)
-      - [inline (read only)](#inline-read-only)
-      - [json (read only)](#json-read-only)
-      - [ndjson (read only)](#ndjson-read-only)
-      - [tsv (read only)](#tsv-read-only)
-      - [html (read only)](#html-read-only)
-    - [Adding support for new file sources, formats, and writers](#adding-support-for-new-file-sources-formats-and-writers)
-      - [Custom loaders](#custom-loaders)
-      - [Custom parsers](#custom-parsers)
-      - [Custom writers](#custom-writers)
+    - [Custom file sources and formats](#custom-file-sources-and-formats)
   - [API Reference](#api-reference)
     - [`cli`](#cli)
-    - [`Stream`](#stream-2)
-      - [`stream.closed`](#streamclosed)
-      - [`stream.encoding`](#streamencoding)
-      - [`stream.format`](#streamformat)
-      - [`stream.fragment`](#streamfragment)
-      - [`stream.hash`](#streamhash)
-      - [`stream.headers`](#streamheaders)
-      - [`stream.sample`](#streamsample)
-      - [`stream.scheme`](#streamscheme)
-      - [`stream.size`](#streamsize)
-      - [`stream.open`](#streamopen)
-      - [`stream.close`](#streamclose)
-      - [`stream.reset`](#streamreset)
-      - [`stream.iter`](#streamiter)
-      - [`stream.read`](#streamread)
-      - [`stream.save`](#streamsave)
+    - [`Stream`](#stream)
     - [`Loader`](#loader)
-      - [`loader.options`](#loaderoptions)
-      - [`loader.load`](#loaderload)
     - [`Parser`](#parser)
-      - [`parser.closed`](#parserclosed)
-      - [`parser.encoding`](#parserencoding)
-      - [`parser.extended_rows`](#parserextended_rows)
-      - [`parser.options`](#parseroptions)
-      - [`parser.open`](#parseropen)
-      - [`parser.close`](#parserclose)
-      - [`parser.reset`](#parserreset)
     - [`Writer`](#writer)
-      - [`writer.options`](#writeroptions)
-      - [`writer.write`](#writerwrite)
     - [`validate`](#validate)
     - [`TabulatorException`](#tabulatorexception)
     - [`IOError`](#ioerror)
@@ -147,7 +90,7 @@ In the following sections, we'll walk through some usage examples of
 this library. All examples were tested with Python 3.6, but should
 run fine with Python 3.3+.
 
-### Stream
+### Working with Stream
 
 The `Stream` class represents a tabular stream. It takes the file path as the
 `source` argument. For example:
@@ -322,7 +265,7 @@ You can also set it explicitly:
 with Stream('data.csv.ext', compression='gz') as stream:
   stream.read()
 ```
-###### Options
+**Options**
 
 - **filename**: filename in zip file to process (default is first file)
 
@@ -511,7 +454,7 @@ It loads data from AWS S3. For private files you should provide credentials supp
 stream = Stream('s3://bucket/data.csv')
 ```
 
-###### Options
+**Options**
 
 - **s3\_endpoint\_url** - the endpoint URL to use. By default it's `https://s3.amazonaws.com`. For complex use cases, for example, `goodtables`'s runs on a data package this option can be provided as an environment variable `S3_ENDPOINT_URL`.
 
@@ -531,7 +474,7 @@ stream = Stream('data.csv')
 stream = Stream('https://example.com/data.csv')
 ```
 
-###### Options
+**Options**
 
 - **http\_session** - a `requests.Session` object. Read more in the [requests docs][requests-session].
 - **http\_stream** - Enables or disables HTTP streaming, when possible (enabled by default). Disable it if you'd like to preload the whole file into memory.
@@ -572,7 +515,7 @@ while others support both reading and writing.
 stream = Stream('data.csv', delimiter=',')
 ```
 
-###### Options
+**Options**
 
 It supports all options from the Python CSV library. Check [their
 documentation][pydoc-csv] for more information.
@@ -586,7 +529,7 @@ documentation][pydoc-csv] for more information.
 stream = Stream('data.xls', sheet=1)
 ```
 
-###### Options
+**Options**
 
 - **sheet**: Sheet name or number (starting from 1).
 - **fill_merged_cells**: if `True` it will unmerge and fill all merged cells by
@@ -605,7 +548,7 @@ Source should be a valid Open Office document.
 stream = Stream('data.ods', sheet=1)
 ```
 
-###### Options
+**Options**
 
 - **sheet**: Sheet name or number (starting from 1)
 
@@ -626,7 +569,7 @@ Any database URL supported by [sqlalchemy][sqlalchemy].
 stream = Stream('postgresql://name:pass@host:5432/database', table='data')
 ```
 
-###### Options
+**Options**
 
 - **table (required)**: Database table name
 - **order_by**: SQL expression for row ordering (e.g. `name DESC`)
@@ -642,7 +585,7 @@ A [Tabular Data Package][tdp].
 stream = Stream('datapackage.json', resource=1)
 ```
 
-###### Options
+**Options**
 
 - **resource**: Resource name or index (starting from 0)
 
@@ -665,7 +608,7 @@ names to their respective values (see the `inline` format for an example).
 stream = Stream('data.json', property='key1.key2')
 ```
 
-###### Options
+**Options**
 
 - **property**: JSON Path to the property containing the tabular data. For example, considering the JSON `{"response": {"data": [...]}}`, the `property` should be set to `response.data`.
 
@@ -696,11 +639,11 @@ Usually `foramt='html'` would need to be specified explicitly as web URLs don't 
 stream = Stream('http://example.com/some/page.aspx', format='html' selector='.content .data table#id1')
 ```
 
-###### Options
+**Options**
 
 - **selector**: CSS selector for specifying which `table` element to extract. By default it's `table`, which takes the first `table` element in the document.
 
-### Adding support for new file sources, formats, and writers
+### Custom file sources and formats
 
 Tabulator is written with extensibility in mind, allowing you to add support for
 new tabular file formats, schemes (e.g. ssh), and writers (e.g. MongoDB). There
@@ -1316,140 +1259,140 @@ $ make test
 
 Here described only breaking and the most important changes. The full changelog and documentation for all released versions could be found in nicely formatted [commit history](https://github.com/frictionlessdata/tabulator-py/commits/master).
 
-###### v1.31
+#### v1.31
 
 - Added `xlsx` writer
 - Added `html` reader
 
-###### v1.30
+#### v1.30
 
 - Added `adjust_floating_point_error` parameter to the `xlsx` parser
 
-###### v1.29
+#### v1.29
 
 - Implemented the `stream.size` and `stream.hash` properties
 
-###### v1.28
+#### v1.28
 
 - Added SQL writer
 
-###### v1.27
+#### v1.27
 
 - Added `http_timeout` argument for the `http/https` format
 
-###### v1.26
+#### v1.26
 
 - Added `stream.fragment` field showing e.g. Excel sheet's or DP resource's name
 
-###### v1.25
+#### v1.25
 
 - Added support for the `s3` file scheme (data loading from AWS S3)
 
-###### v1.24
+#### v1.24
 
 - Added support for compressed file-like objects
 
-###### v1.23
+#### v1.23
 
 - Added a setter for the `stream.headers` property
 
-###### v1.22
+#### v1.22
 
 - The `headers` parameter will now use the first not skipped row if the `skip_rows` parameter is provided and there are comments on the top of a data source (see #264)
 
-###### v1.21
+#### v1.21
 
 - Implemented experimental `preserve_formatting` for xlsx
 
-###### v1.20
+#### v1.20
 
 - Added support for specifying filename in zip source
 
-###### v1.19
+#### v1.19
 
 Updated behaviour:
 - For `ods` format the boolean, integer and datatime native types are detected now
 
-###### v1.18
+#### v1.18
 
 Updated behaviour:
 - For `xls` format the boolean, integer and datatime native types are detected now
 
-###### v1.17
+#### v1.17
 
 Updated behaviour:
 - Added support for Python 3.7
 
-###### v1.16
+#### v1.16
 
 New API added:
 - `skip_rows` support for an empty string to skip rows with an empty first column
 
-###### v1.15
+#### v1.15
 
 New API added:
 - Format will be extracted from URLs like `http://example.com?format=csv`
 
-###### v1.14
+#### v1.14
 
 Updated behaviour:
 - Now `xls` booleans will be parsed as booleans not integers
 
-###### v1.13
+#### v1.13
 
 New API added:
 - The `skip_rows` argument now supports negative numbers to skip rows starting from the end
 
-###### v1.12
+#### v1.12
 
 Updated behaviour:
 - Instead of raising an exception, a `UserWarning` warning will be emitted if an option isn't recognized.
 
-###### v1.11
+#### v1.11
 
 New API added:
 - Added `http_session` argument for the `http/https` format (it uses `requests` now)
 - Added support for multiline headers: `headers` argument accept ranges like `[1,3]`
 
-###### v1.10
+#### v1.10
 
 New API added:
 - Added support for compressed files i.e. `zip` and `gz` on Python3
 - The `Stream` constructor now accepts a `compression` argument
 - The `http/https` scheme now accepts a `http_stream` flag
 
-###### v1.9
+#### v1.9
 
 Improved behaviour:
 - The `headers` argument allows to set the order for keyed sources and cherry-pick values
 
-###### v1.8
+#### v1.8
 
 New API added:
 - Formats `XLS/XLSX/ODS` supports sheet names passed via the `sheet` argument
 - The `Stream` constructor accepts an `ignore_blank_headers` option
 
-###### v1.7
+#### v1.7
 
 Improved behaviour:
 - Rebased `datapackage` format on `datapackage@1` library
 
-###### v1.6
+#### v1.6
 
 New API added:
 - Argument `source` for the `Stream` constructor can be a `pathlib.Path`
 
-###### v1.5
+#### v1.5
 
 New API added:
 - Argument `bytes_sample_size` for the `Stream` constructor
 
-###### v1.4
+#### v1.4
 
 Improved behaviour:
 - Updated encoding name to a canonical form
 
-###### v1.3
+#### v1.3
 
 New API added:
 - `stream.scheme`
@@ -1462,17 +1405,17 @@ Promoted provisional API to stable API:
 - `Writer` (custom writers)
 - `validate`
 
-###### v1.2
+#### v1.2
 
 Improved behaviour:
 - Autodetect common CSV delimiters
 
-###### v1.1
+#### v1.1
 
 New API added:
 - Added `fill_merged_cells` option to `xls/xlsx` formats
 
-###### v1.0
+#### v1.0
 
 New API added:
 - published `Loader/Parser/Writer` API
@@ -1487,7 +1430,7 @@ Deprecated API removal:
 Provisional API changed:
 - Updated the `Loader/Parser/Writer` API - please use an updated version
 
-###### v0.15
+#### v0.15
 
 Provisional API added:
 - Unofficial support for `Stream` arguments `custom_loaders/parsers`

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ A library for reading and writing tabular data (csv/xls/json/etc).
       - [Custom loaders](#custom-loaders)
       - [Custom parsers](#custom-parsers)
       - [Custom writers](#custom-writers)
-    - [Validate](#validate)
-    - [Exceptions](#exceptions)
   - [API Reference](#api-reference)
     - [`cli`](#cli)
     - [`Stream`](#stream-2)
@@ -96,7 +94,7 @@ A library for reading and writing tabular data (csv/xls/json/etc).
     - [`Writer`](#writer)
       - [`writer.options`](#writeroptions)
       - [`writer.write`](#writerwrite)
-    - [`validate`](#validate-1)
+    - [`validate`](#validate)
     - [`TabulatorException`](#tabulatorexception)
     - [`IOError`](#ioerror)
     - [`HTTPError`](#httperror)
@@ -815,28 +813,6 @@ with Stream(source, custom_writers={'custom': CustomWriter}) as stream:
 
 You can see examples of how parsers are implemented by looking in the
 `tabulator.writers` module.
-
-### Validate
-
-You can check if a source can be loaded by tabulator using the `validate` function.
-
-```python
-from tabulator import validate, exceptions
-
-try:
-    tabular = validate('data.csv')
-except exceptions.SchemeError:
-    # The file scheme isn't supported
-except exceptions.FormatError:
-    # The file format isn't supported
-```
-
-### Exceptions
-
-All the exceptions thrown by tabulator inherit from
-`tabulator.exceptions.TabulatorException`, so you can use it as a way to catch
-any tabulator exception. You can learn about the other exceptions thrown by
-looking into the [tabulator.exceptions][tabulator.exceptions] module.
 
 ## API Reference
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'tabulator = tabulator.cli:cli',
+            'tabulator = tabulator.__main__:cli',
         ]
     },
     zip_safe=False,

--- a/tabulator/__init__.py
+++ b/tabulator/__init__.py
@@ -3,21 +3,25 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+from . import config
+__version__ = config.VERSION
 
 
 # Module API
 
+from .cli import cli
 from .stream import Stream
 from .loader import Loader
 from .parser import Parser
 from .writer import Writer
 from .validate import validate
+from .exceptions import TabulatorException
+from .exceptions import IOError
+from .exceptions import HTTPError
+from .exceptions import SourceError
+from .exceptions import FormatError
+from .exceptions import EncodingError
+
+# Deprecated
+
 from . import exceptions
-
-# Version
-
-import io
-import os
-__version__ = io.open(
-    os.path.join(os.path.dirname(__file__), 'VERSION'),
-    encoding='utf-8').read().strip()

--- a/tabulator/__main__.py
+++ b/tabulator/__main__.py
@@ -1,0 +1,7 @@
+from .cli import cli
+
+
+# Module API
+
+if __name__ == "__main__":
+    cli()

--- a/tabulator/cli.py
+++ b/tabulator/cli.py
@@ -7,19 +7,36 @@ from __future__ import absolute_import
 import six
 import click
 import tabulator
+from . import config
 
 
 # Module API
 
-@click.command()
+@click.command(help='')
 @click.argument('source')
 @click.option('--headers', type=click.INT)
 @click.option('--scheme')
 @click.option('--format')
 @click.option('--encoding')
 @click.option('--limit', type=click.INT)
-@click.version_option(tabulator.__version__, message='%(version)s')
+@click.version_option(config.VERSION, message='%(version)s')
 def cli(source, limit, **options):
+    """Command-line interface
+
+    ```
+    Usage: tabulator [OPTIONS] SOURCE
+
+    Options:
+      --headers INTEGER
+      --scheme TEXT
+      --format TEXT
+      --encoding TEXT
+      --limit INTEGER
+      --version          Show the version and exit.
+      --help             Show this message and exit.
+    ```
+
+    """
     options = {key: value for key, value in options.items() if value is not None}
     with tabulator.Stream(source, **options) as stream:
         cast = str
@@ -31,9 +48,3 @@ def cli(source, limit, **options):
             click.echo(','.join(map(cast, row)))
             if count == limit:
                 break
-
-
-# Main program
-
-if __name__ == '__main__':
-    cli()

--- a/tabulator/config.py
+++ b/tabulator/config.py
@@ -4,9 +4,13 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import io
+import os
+
 
 # General
 
+VERSION = io.open(os.path.join(os.path.dirname(__file__), 'VERSION')).read().strip()
 DEFAULT_SCHEME = 'file'
 DEFAULT_ENCODING = 'utf-8'
 DEFAULT_SAMPLE_SIZE = 100

--- a/tabulator/exceptions.py
+++ b/tabulator/exceptions.py
@@ -8,34 +8,44 @@ from __future__ import unicode_literals
 # Module API
 
 class TabulatorException(Exception):
-    '''Base class for all tabulator exceptions.'''
+    """Base class for all tabulator exceptions.
+    """
     pass
 
 
 class IOError(TabulatorException):
+    """Local loading error
+    """
     pass
 
 
 class HTTPError(IOError):
+    """Remote loading error
+    """
     pass
 
 
 class SourceError(TabulatorException):
-    '''The source file could not be parsed correctly.'''
+    """The source file could not be parsed correctly.
+    """
     pass
 
 
 class SchemeError(TabulatorException):
-    '''The file scheme is not supported.'''
+    """The file scheme is not supported.
+    """
     pass
 
 
 class FormatError(TabulatorException):
-    '''The file format is unsupported or invalid.'''
+    """The file format is unsupported or invalid.
+    """
     pass
 
 
 class EncodingError(TabulatorException):
+    """Encoding error
+    """
     pass
 
 

--- a/tabulator/loader.py
+++ b/tabulator/loader.py
@@ -12,18 +12,16 @@ from abc import ABCMeta, abstractmethod
 
 @add_metaclass(ABCMeta)
 class Loader(object):
-    '''Abstract class implemented by the data loaders
+    """Abstract class implemented by the data loaders
 
     The loaders inherit and implement this class' methods to add support for a
     new scheme (e.g. ssh).
 
-    Args:
+    # Arguments
         bytes_sample_size (int): Sample size in bytes
         **options (dict): Loader options
 
-    Returns:
-        Loader: Loader instance.
-    '''
+    """
 
     # Public
 
@@ -34,15 +32,17 @@ class Loader(object):
 
     @abstractmethod
     def load(self, source, mode='t', encoding=None):
-        '''Load source file.
+        """Load source file.
 
-        Args:
+        # Arguments
             source (str): Path to tabular source file.
-            mode (str, optional): Text stream mode, `t` (text) or `b` (binary).
-                Defaults to `t`.
-            encoding (str, optional): Source encoding. Auto-detect by default.
+            mode (str, optional):
+                Text stream mode, `t` (text) or `b` (binary).  Defaults to `t`.
+            encoding (str, optional):
+                Source encoding. Auto-detect by default.
 
-        Returns:
+        # Returns
             Union[TextIO, BinaryIO]: I/O stream opened either as text or binary.
-        '''
+
+        """
         pass

--- a/tabulator/parser.py
+++ b/tabulator/parser.py
@@ -12,22 +12,21 @@ from abc import ABCMeta, abstractmethod
 
 @add_metaclass(ABCMeta)
 class Parser(object):
-    '''Abstract class implemented by the data parsers.
+    """Abstract class implemented by the data parsers.
 
     The parsers inherit and implement this class' methods to add support for a
     new file type.
 
-    Args:
+    # Arguments
         loader (tabulator.Loader): Loader instance to read the file.
-        force_parse (bool): When `True`, the parser yields an empty extended
+        force_parse (bool):
+            When `True`, the parser yields an empty extended
             row tuple `(row_number, None, [])` when there is an error parsing a
             row. Otherwise, it stops the iteration by raising the exception
             `tabulator.exceptions.SourceError`.
         **options (dict): Loader options
 
-    Returns:
-        Parser: Parser instance.
-    '''
+    """
 
     # Public
 
@@ -39,61 +38,76 @@ class Parser(object):
     @property
     @abstractmethod
     def closed(self):
-        '''Flag telling if the parser is closed.'''
+        """Flag telling if the parser is closed.
+
+        # Returns
+            bool: whether closed
+
+        """
         pass  # pragma: no cover
 
     @abstractmethod
     def open(self, source, encoding=None):
-        '''Open underlying file stream in the beginning of the file.
+        """Open underlying file stream in the beginning of the file.
 
         The parser gets a byte or text stream from the `tabulator.Loader`
         instance and start emitting items.
 
-        Args:
+        # Arguments
             source (str): Path to source table.
             encoding (str, optional): Source encoding. Auto-detect by default.
 
-        Returns:
+        # Returns
             None
-        '''
+
+        """
         pass  # pragma: no cover
 
     @abstractmethod
     def close(self):
-        '''Closes underlying file stream.'''
+        """Closes underlying file stream.
+        """
         pass  # pragma: no cover
 
     @abstractmethod
     def reset(self):
-        '''Resets underlying stream and current items list.
+        """Resets underlying stream and current items list.
 
-        After `reset()` is called, iterating over the items will start from the
-        beginning.
-        '''
+        After `reset()` is called, iterating over the items will start from the beginning.
+        """
         pass  # pragma: no cover
 
     @property
     @abstractmethod
     def encoding(self):
+        """Encoding
+
+        # Returns
+            str: encoding
+
+        """
         pass  # pragma: no cover
 
     @property
     @abstractmethod
     def extended_rows(self):
-        '''Returns extended rows iterator.
+        """Returns extended rows iterator.
 
         The extended rows are tuples containing `(row_number, headers, row)`,
 
-        Yields:
-            Tuple[int, List[str], List[Any]]: Extended rows containing
+        # Raises
+            SourceError:
+                If `force_parse` is `False` and
+                a row can't be parsed, this exception will be raised.
+                Otherwise, an empty extended row is returned (i.e.
+                `(row_number, None, [])`).
+
+        Returns:
+            Iterator[Tuple[int, List[str], List[Any]]]:
+                Extended rows containing
                 `(row_number, headers, row)`, where `headers` is a list of the
                 header names (can be `None`), and `row` is a list of row
                 values.
 
-        Raises:
-            `tabulator.exceptions.SourceError`: If `force_parse` is `False` and
-                a row can't be parsed, this exception will be raised.
-                Otherwise, an empty extended row is returned (i.e.
-                `(row_number, None, [])`).
-        '''
+        """
         pass  # pragma: no cover

--- a/tabulator/stream.py
+++ b/tabulator/stream.py
@@ -21,64 +21,96 @@ from . import config
 # Module API
 
 class Stream(object):
-    '''Stream of tabular data.
+    """Stream of tabular data.
 
     This is the main `tabulator` class. It loads a data source, and allows you
     to stream its parsed contents.
 
-    Args:
-        source (str): Path to file as ``<scheme>://path/to/file.<format>``. If
+    # Arguments
+
+        source (str):
+            Path to file as ``<scheme>://path/to/file.<format>``. If
             not explicitly set, the scheme (file, http, ...) and format (csv, xls,
             ...) are inferred from the source string.
-        headers (Union[int, List[int], List[str]], optional): Either a row
+
+        headers (Union[int, List[int], List[str]], optional):
+            Either a row
             number or list of row numbers (in case of multi-line headers) to be
             considered as headers (rows start counting at 1), or the actual
             headers defined a list of strings. If not set, all rows will be
             treated as containing values.
-        scheme (str, optional): Scheme for loading the file (file, http, ...).
-             If not set, it'll be inferred from `source`.
-        format (str, optional): File source's format (csv, xls, ...). If not
-             set, it'll be inferred from `source`. inferred
-        encoding (str, optional): Source encoding. If not set, it'll be inferred.
-        compression (str, optional): Source file compression (zip, ...). If not
-            set, it'll be inferred.
-        allow_html (bool, optional): Allow the file source to be an HTML page.
+
+        scheme (str, optional):
+            Scheme for loading the file (file, http, ...).
+            If not set, it'll be inferred from `source`.
+
+        format (str, optional):
+            File source's format (csv, xls, ...). If not
+            set, it'll be inferred from `source`. inferred
+
+        encoding (str, optional):
+            Source encoding. If not set, it'll be inferred.
+
+        compression (str, optional):
+            Source file compression (zip, ...). If not set, it'll be inferred.
+
+        allow_html (bool, optional):
+            Allow the file source to be an HTML page.
             If False, raises ``exceptions.FormatError`` if the loaded file is
             an HTML page. Defaults to False.
-        sample_size (int, optional): Controls the number of sample rows used to
+
+        sample_size (int, optional):
+            Controls the number of sample rows used to
             infer properties from the data (headers, encoding, etc.). Set to
             ``0`` to disable sampling, in which case nothing will be inferred
             from the data. Defaults to ``config.DEFAULT_SAMPLE_SIZE``.
-        bytes_sample_size (int, optional): Same as `sample_size`, but instead
+
+        bytes_sample_size (int, optional):
+            Same as `sample_size`, but instead
             of number of rows, controls number of bytes. Defaults to
             ``config.DEFAULT_BYTES_SAMPLE_SIZE``.
-        ignore_blank_headers (bool, optional): When True, ignores all columns
+
+        ignore_blank_headers (bool, optional):
+            When True, ignores all columns
             that have blank headers. Defaults to False.
-        force_strings (bool, optional): When True, casts all data to strings.
+
+        force_strings (bool, optional):
+            When True, casts all data to strings.
             Defaults to False.
-        force_parse (bool, optional): When True, don't raise exceptions when
+
+        force_parse (bool, optional):
+            When True, don't raise exceptions when
             parsing malformed rows, simply returning an empty value. Defaults
             to False.
-        skip_rows (List[Union[int, str]], optional): List of row numbers and
+
+        skip_rows (List[Union[int, str]], optional):
+            List of row numbers and
             strings to skip. If a string, it'll skip rows that begin with it
             (e.g. '#' and '//').
-        post_parse (List[function], optional): List of generator functions that
+
+        post_parse (List[function], optional):
+            List of generator functions that
             receives a list of rows and headers, processes them, and yields
             them (or not). Useful to pre-process the data. Defaults to None.
-        custom_loaders (dict, optional): Dictionary with keys as scheme names,
+
+        custom_loaders (dict, optional):
+            Dictionary with keys as scheme names,
             and values as their respective ``Loader`` class implementations.
             Defaults to None.
-        custom_parsers (dict, optional): Dictionary with keys as format names,
+
+        custom_parsers (dict, optional):
+            Dictionary with keys as format names,
             and values as their respective ``Parser`` class implementations.
             Defaults to None.
-        custom_loaders (dict, optional): Dictionary with keys as writer format
+
+        custom_loaders (dict, optional):
+            Dictionary with keys as writer format
             names, and values as their respective ``Writer`` class
             implementations. Defaults to None.
+
         **options (Any, optional): Extra options passed to the loaders and parsers.
 
-    Returns:
-        Stream: The Stream instance.
-    '''
+    """
 
     # Public
 
@@ -172,11 +204,21 @@ class Stream(object):
 
     @property
     def closed(self):
-        '''Returns True if the underlying stream is closed, False otherwise.'''
+        """Returns True if the underlying stream is closed, False otherwise.
+
+        # Returns
+            bool: whether closed
+
+        """
         return not self.__parser or self.__parser.closed
 
     def open(self):
-        '''Opens the stream for reading.'''
+        """Opens the stream for reading.
+
+        # Raises:
+            TabulatorException: if an error
+
+        """
         source = self.__source
         options = copy(self.__options)
 
@@ -285,12 +327,14 @@ class Stream(object):
         return self
 
     def close(self):
-        '''Closes the stream.'''
+        """Closes the stream.
+        """
         self.__parser.close()
         self.__row_number = 0
 
     def reset(self):
-        '''Resets the stream pointer to the beginning of the file.'''
+        """Resets the stream pointer to the beginning of the file.
+        """
         if self.__row_number > self.__sample_size:
             self.__stats = {'size': 0, 'hash': ''}
             self.__parser.reset()
@@ -300,33 +344,73 @@ class Stream(object):
 
     @property
     def headers(self):
+        """Headers
+
+        # Returns
+            str[]/None: headers if available
+
+        """
         return self.__headers
 
     @headers.setter
     def headers(self, headers):
+        """Set headers
+
+        # Arguments
+            str[]: headers
+
+        """
         self.__headers = headers
 
     @property
     def scheme(self):
+        """Path's scheme
+
+        # Returns
+            str: scheme
+
+        """
         return self.__actual_scheme
 
     @property
     def fragment(self):
+        """Path's fragment
+
+        # Returns
+            str: fragment
+
+        """
         if self.__parser:
             return getattr(self.__parser, 'fragment', None)
         return None
 
     @property
     def format(self):
+        """Path's format
+
+        # Returns
+            str: format
+
+        """
         return self.__actual_format
 
     @property
     def encoding(self):
+        """Stream's encoding
+
+        # Returns
+            str: encoding
+
+        """
         return self.__actual_encoding
 
     @property
     def size(self):
         """Returns the BYTE count of the read chunks if available
+
+        # Returns
+            int/None: BYTE count
+
         """
         if self.__stats:
             return self.__stats['size']
@@ -334,17 +418,25 @@ class Stream(object):
     @property
     def hash(self):
         """Returns the SHA256 hash of the read chunks if available
+
+        # Returns
+            str/None: SHA256 hash
+
         """
         if self.__stats:
             return self.__stats['hash']
 
     @property
     def sample(self):
-        '''Returns the stream's rows used as sample.
+        """Returns the stream's rows used as sample.
 
         These sample rows are used internally to infer characteristics of the
         source file (e.g. encoding, headers, ...).
-        '''
+
+        # Returns
+            list[]: sample
+
+        """
         sample = []
         iterator = iter(self.__sample_extended_rows)
         iterator = self.__apply_processors(iterator)
@@ -353,30 +445,33 @@ class Stream(object):
         return sample
 
     def iter(self, keyed=False, extended=False):
-        '''Iterate over the rows.
+        """Iterate over the rows.
 
         Each row is returned in a format that depends on the arguments `keyed`
         and `extended`. By default, each row is returned as list of their
         values.
 
-        Args:
-            keyed (bool, optional): When True, each returned row will be a
+        # Arguments
+            keyed (bool, optional):
+                When True, each returned row will be a
                 `dict` mapping the header name to its value in the current row.
-                For example, `[{'name': 'J Smith', 'value': '10'}]`. Ignored if
+                For example, `[{'name'\\: 'J Smith', 'value'\\: '10'}]`. Ignored if
                 ``extended`` is True. Defaults to False.
-            extended (bool, optional): When True, returns each row as a tuple
+            extended (bool, optional):
+                When True, returns each row as a tuple
                 with row number (starts at 1), list of headers, and list of row
                 values. For example, `(1, ['name', 'value'], ['J Smith', '10'])`.
                 Defaults to False.
 
-        Returns:
+        # Raises
+            exceptions.TabulatorException: If the stream is closed.
+
+        # Returns
             Iterator[Union[List[Any], Dict[str, Any], Tuple[int, List[str], List[Any]]]]:
                 The row itself. The format depends on the values of `keyed` and
                 `extended` arguments.
 
-        Raises:
-            exceptions.TabulatorException: If the stream is closed.
-        '''
+        """
 
         # Error if closed
         if self.closed:
@@ -401,19 +496,19 @@ class Stream(object):
                     yield row
 
     def read(self, keyed=False, extended=False, limit=None):
-        '''Returns a list of rows.
+        """Returns a list of rows.
 
-        Args:
+        # Arguments
             keyed (bool, optional): See :func:`Stream.iter`.
             extended (bool, optional): See :func:`Stream.iter`.
-            limit (int, optional): Number of rows to return. If None, returns
-            all rows. Defaults to None.
+            limit (int, optional):
+                Number of rows to return. If None, returns all rows. Defaults to None.
 
-        Returns:
+        # Returns
             List[Union[List[Any], Dict[str, Any], Tuple[int, List[str], List[Any]]]]:
                 The list of rows. The format depends on the values of `keyed`
                 and `extended` arguments.
-        '''
+        """
         result = []
         rows = self.iter(keyed=keyed, extended=extended)
         for count, row in enumerate(rows, start=1):
@@ -423,16 +518,18 @@ class Stream(object):
         return result
 
     def save(self, target, format=None,  encoding=None, **options):
-        '''Save stream to the local filesystem.
+        """Save stream to the local filesystem.
 
-        Args:
+        # Arguments:
             target (str): Path where to save the stream.
-            format (str, optional): The format the stream will be saved as. If
+            format (str, optional):
+                The format the stream will be saved as. If
                 None, detects from the ``target`` path. Defaults to None.
-            encoding (str, optional): Saved file encoding. Defaults to
-                ``config.DEFAULT_ENCODING``.
+            encoding (str, optional):
+                Saved file encoding. Defaults to ``config.DEFAULT_ENCODING``.
             **options: Extra options passed to the writer.
-        '''
+
+        """
 
         # Get encoding/format
         if encoding is None:

--- a/tabulator/stream.py
+++ b/tabulator/stream.py
@@ -29,9 +29,9 @@ class Stream(object):
     # Arguments
 
         source (str):
-            Path to file as ``<scheme>://path/to/file.<format>``. If
-            not explicitly set, the scheme (file, http, ...) and format (csv, xls,
-            ...) are inferred from the source string.
+            Path to file as ``<scheme>\\://path/to/file.<format>``.
+            If not explicitly set, the scheme (file, http, ...) and
+            format (csv, xls, ...) are inferred from the source string.
 
         headers (Union[int, List[int], List[str]], optional):
             Either a row

--- a/tabulator/validate.py
+++ b/tabulator/validate.py
@@ -12,20 +12,21 @@ from . import exceptions
 # Module API
 
 def validate(source, scheme=None, format=None):
-    '''Check if tabulator is able to load the source.
+    """Check if tabulator is able to load the source.
 
-    Args:
+    # Arguments
         source (Union[str, IO]): The source path or IO object.
         scheme (str, optional): The source scheme. Auto-detect by default.
         format (str, optional): The source file format. Auto-detect by default.
 
-    Returns:
+    # Raises
+        SchemeError: The file scheme is not supported.
+        FormatError: The file format is not supported.
+
+    # Returns
         bool: Whether tabulator is able to load the source file.
 
-    Raises:
-        `tabulator.exceptions.SchemeError`: The file scheme is not supported.
-        `tabulator.exceptions.FormatError`: The file format is not supported.
-    '''
+    """
 
     # Get scheme and format
     detected_scheme, detected_format = helpers.detect_scheme_and_format(source)

--- a/tabulator/writer.py
+++ b/tabulator/writer.py
@@ -12,17 +12,15 @@ from abc import ABCMeta, abstractmethod
 
 @add_metaclass(ABCMeta)
 class Writer(object):
-    '''Abstract class implemented by the data writers.
+    """Abstract class implemented by the data writers.
 
     The writers inherit and implement this class' methods to add support for a
     new file destination.
 
-    Args:
+    # Arguments
         **options (dict): Writer options.
 
-    Returns:
-        Writer: Writer instance.
-    '''
+    """
 
     # Public
 
@@ -33,12 +31,13 @@ class Writer(object):
 
     @abstractmethod
     def write(self, source, target, headers, encoding=None):
-        '''Writes source data to target.
+        """Writes source data to target.
 
-        Args:
+        # Arguments
             source (str): Source data.
             target (str): Write target.
             headers (List[str]): List of header names.
             encoding (str, optional): Source file encoding.
-        '''
+
+        """
         pass


### PR DESCRIPTION
We rebase on pydoc-markdown which is really close to the almost standard Google docstrings syntax
