### PR TITLE
Implemented `blank` preset for `skip_rows`

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,8 @@ __Arguments__
 - __skip_rows (List[Union[int, str, dict]], optional)__:
         List of row numbers, strings and regex patterns as dicts to skip.
         If a string, it'll skip rows that their first cells begin with it e.g. '#' and '//'.
-        To provide a regex pattern use an object like `{'type': 'regex', 'value': '^#'}`
+        To skip only completely blank rows use `{'type': 'preset', 'value': 'blank'}`
+        To provide a regex pattern use  `{'type': 'regex', 'value': '^#'}`
         For example: `skip_rows=[1, '# comment', {'type': 'regex', 'value': '^# (regex|comment)'}]`
 - __skip_columns (str[])__:
         Alias for `ignore_listed_headers`.

--- a/tabulator/stream.py
+++ b/tabulator/stream.py
@@ -100,7 +100,8 @@ class Stream(object):
         skip_rows (List[Union[int, str, dict]], optional):
             List of row numbers, strings and regex patterns as dicts to skip.
             If a string, it'll skip rows that their first cells begin with it e.g. '#' and '//'.
-            To provide a regex pattern use an object like `{'type'\\: 'regex', 'value'\\: '^#'}`
+            To skip only completely blank rows use `{'type'\\: 'preset', 'value'\\: 'blank'}`
+            To provide a regex pattern use  `{'type'\\: 'regex', 'value'\\: '^#'}`
             For example\\: `skip_rows=[1, '# comment', {'type'\\: 'regex', 'value'\\: '^# (regex|comment)'}]`
 
         skip_columns (str[]):
@@ -189,12 +190,17 @@ class Stream(object):
         self.__skip_rows_by_numbers = []
         self.__skip_rows_by_patterns = []
         self.__skip_rows_by_comments = []
+        self.__skip_rows_by_presets = {}
         for directive in copy(skip_rows):
             if isinstance(directive, int):
                 self.__skip_rows_by_numbers.append(directive)
             elif isinstance(directive, dict):
-                assert directive['type'] == 'regex'
-                self.__skip_rows_by_patterns.append(re.compile(directive['value']))
+                if directive['type'] == 'regex':
+                    self.__skip_rows_by_patterns.append(re.compile(directive['value']))
+                elif directive['type'] == 'preset' and directive['value'] == 'blank':
+                    self.__skip_rows_by_presets['blank'] = True
+                else:
+                    raise ValueError('Not supported skip rows: %s' % directive)
             else:
                 self.__skip_rows_by_comments.append(str(directive))
 
@@ -779,9 +785,14 @@ class Stream(object):
         # Get first cell
         cell = row[0] if row else None
 
-        # Handle empty cell
+        # Handle blank cell/row
         if cell in [None, '']:
-            return '' in self.__skip_rows_by_comments
+            if '' in self.__skip_rows_by_comments:
+                return True
+            if self.__skip_rows_by_presets.get('blank'):
+                if not any(row):
+                    return True
+            return False
 
         # Skip by pattern
         for pattern in self.__skip_rows_by_patterns:

--- a/tabulator/stream.py
+++ b/tabulator/stream.py
@@ -790,7 +790,7 @@ class Stream(object):
             if '' in self.__skip_rows_by_comments:
                 return True
             if self.__skip_rows_by_presets.get('blank'):
-                if not any(row):
+                if not list(filter(lambda cell: cell not in [None, ''], row)):
                     return True
             return False
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -441,11 +441,11 @@ def test_stream_skip_rows_regex():
 
 
 def test_stream_skip_rows_preset():
-    source = [['name', 'order'], ['', ''], [], ['John', 1], ['Alex', 2]]
+    source = [['name', 'order'], ['', ''], [], ['Ray', 0], ['John', 1], ['Alex', 2], ['', 3], [None, 4], ['', None]]
     skip_rows = [{'type': 'preset', 'value': 'blank'}]
     with Stream(source, headers=1, skip_rows=skip_rows) as stream:
         assert stream.headers == ['name', 'order']
-        assert stream.read() == [['John', 1], ['Alex', 2]]
+        assert stream.read() == [['Ray', 0], ['John', 1], ['Alex', 2], ['', 3], [None, 4]]
 
 
 # Post parse

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -440,6 +440,14 @@ def test_stream_skip_rows_regex():
         assert stream.read() == [['John', 1], ['Alex', 2]]
 
 
+def test_stream_skip_rows_preset():
+    source = [['name', 'order'], ['', ''], [], ['John', 1], ['Alex', 2]]
+    skip_rows = [{'type': 'preset', 'value': 'blank'}]
+    with Stream(source, headers=1, skip_rows=skip_rows) as stream:
+        assert stream.headers == ['name', 'order']
+        assert stream.read() == [['John', 1], ['Alex', 2]]
+
+
 # Post parse
 
 def test_stream_post_parse_headers():


### PR DESCRIPTION
- fixes #300 

---

Hi @mcarans,

Here is an option for skipping completely blank rows based on `goodtables-py` definition of blank rows. It's based on the @cschloer's idea of supporting regex patterns.

Will it work for your case?
